### PR TITLE
Fix memory leak

### DIFF
--- a/src/AnimatedGifEnumerator.cs
+++ b/src/AnimatedGifEnumerator.cs
@@ -76,30 +76,27 @@ namespace StbImageSharp
 
 		protected unsafe virtual void Dispose(bool disposing)
 		{
-			if (disposing)
+			if (_gif != null)
 			{
-				if (_gif != null)
+				if (_gif._out_ != null)
 				{
-					if (_gif._out_ != null)
-					{
-						CRuntime.free(_gif._out_);
-						_gif._out_ = null;
-					}
-
-					if (_gif.history != null)
-					{
-						CRuntime.free(_gif.history);
-						_gif.history = null;
-					}
-
-					if (_gif.background != null)
-					{
-						CRuntime.free(_gif.background);
-						_gif.background = null;
-					}
-
-					_gif = null;
+					CRuntime.free(_gif._out_);
+					_gif._out_ = null;
 				}
+
+				if (_gif.history != null)
+				{
+					CRuntime.free(_gif.history);
+					_gif.history = null;
+				}
+
+				if (_gif.background != null)
+				{
+					CRuntime.free(_gif.background);
+					_gif.background = null;
+				}
+
+				_gif = null;
 			}
 		}
 	}


### PR DESCRIPTION
`disposing` is only intended to be used to conditionally clean up *managed* resources, which the gif data is not.

The existence of a memory leak can be demonstrated via the following code:
```cs
while (true) {
    using var stream = _assembly.OpenResourceStream(fileName);
    ImageResult.AnimatedGifFramesFromStream(stream).GetEnumerator().MoveNext();
}
```
(I just plopped it at the start of the `AnimatedGifFrames` test.)