### PR TITLE
Utilize Span

### DIFF
--- a/src/AnimatedGifEnumerator.cs
+++ b/src/AnimatedGifEnumerator.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace StbImageSharp
 {
@@ -51,15 +50,13 @@ namespace StbImageSharp
 					Width = _gif.w,
 					Height = _gif.h,
 					SourceComp = (ColorComponents)ccomp,
-					Comp = ColorComponents == ColorComponents.Default ? (ColorComponents)ccomp : ColorComponents
+					Comp = ColorComponents == ColorComponents.Default ? (ColorComponents)ccomp : ColorComponents,
+					DataPtr = result,
 				};
-
-				Current.Data = new byte[Current.Width * Current.Height * (int)Current.Comp];
+				Current.DataLength = Current.Width * Current.Height * (int)Current.Comp;
 			}
 
 			Current.DelayInMs = _gif.delay;
-
-			Marshal.Copy(new IntPtr(result), Current.Data, 0, Current.Data.Length);
 
 			return true;
 		}
@@ -76,6 +73,15 @@ namespace StbImageSharp
 
 		protected unsafe virtual void Dispose(bool disposing)
 		{
+			if (Current != null)
+			{
+				// We do not want to free the data pointer here,
+				// because it is owned by the gif object
+				Current.DataPtr = null;
+				Current.Dispose();
+				Current = null;
+			}
+
 			if (_gif != null)
 			{
 				if (_gif._out_ != null)

--- a/src/AnimatedGifEnumerator.cs
+++ b/src/AnimatedGifEnumerator.cs
@@ -76,30 +76,27 @@ namespace StbImageSharp
 
 		protected unsafe virtual void Dispose(bool disposing)
 		{
-			if (disposing)
+			if (_gif != null)
 			{
-				if (_gif != null)
+				if (_gif._out_ != null)
 				{
-					if (_gif._out_ != null)
-					{
-						CRuntime.free(_gif._out_);
-						_gif._out_ = null;
-					}
-
-					if (_gif.history != null)
-					{
-						CRuntime.free(_gif.history);
-						_gif.history = null;
-					}
-
-					if (_gif.background != null)
-					{
-						CRuntime.free(_gif.background);
-						_gif.background = null;
-					}
-
-					_gif = null;
+					CRuntime.free(_gif._out_);
+					_gif._out_ = null;
 				}
+
+				if (_gif.history != null)
+				{
+					CRuntime.free(_gif.history);
+					_gif.history = null;
+				}
+
+				if (_gif.background != null)
+				{
+					CRuntime.free(_gif.background);
+					_gif.background = null;
+				}
+
+				_gif = null;
 			}
 		}
 	}

--- a/src/StbImageSharp.csproj
+++ b/src/StbImageSharp.csproj
@@ -3,7 +3,7 @@
         <Authors>StbImageSharpTeam</Authors>
         <Product>StbImageSharp</Product>
         <PackageId>StbImageSharp</PackageId>
-        <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net5</TargetFrameworks>
         <Description>C# port of the stb_image.h</Description>
         <PackageLicenseUrl>Public Domain</PackageLicenseUrl>
         <PackageProjectUrl>https://github.com/StbSharp/StbImageSharp</PackageProjectUrl>

--- a/tests/StbImageSharp.Tests/StbImageSharp.Tests.csproj
+++ b/tests/StbImageSharp.Tests/StbImageSharp.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   
   <ItemGroup>

--- a/tests/StbImageSharp.Tests/Tests.cs
+++ b/tests/StbImageSharp.Tests/Tests.cs
@@ -17,49 +17,40 @@ namespace StbImageSharp.Tests
 		public void LoadUnknownFormat(string filename)
 		{
 			Assert.Throws<InvalidOperationException>(() =>
-			{
-				ImageResult result = null;
-				using (var stream = _assembly.OpenResourceStream(filename))
-				{
-					result = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
-				}
+			{ 
+				using var stream = _assembly.OpenResourceStream(filename);
+				using var result = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
 			});
 		}
 
 		[TestCase("sample_1280×853.hdr", 1280, 853, ColorComponents.RedGreenBlue)]
 		[TestCase("DockPanes.jpg", 609, 406, ColorComponents.RedGreenBlue)]
-		public void Load(string filename, int width, int height, ColorComponents colorComponents)
+		public unsafe void Load(string filename, int width, int height, ColorComponents colorComponents)
 		{
-			ImageResult result = null;
-			using (var stream = _assembly.OpenResourceStream(filename))
-			{
-				result = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
-			}
+			using var stream = _assembly.OpenResourceStream(filename);
+			using var result = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
 
 			Assert.IsNotNull(result);
 			Assert.AreEqual(result.Width, width);
 			Assert.AreEqual(result.Height, height);
 			Assert.AreEqual(result.Comp, ColorComponents.RedGreenBlueAlpha);
 			Assert.AreEqual(result.SourceComp, colorComponents);
-			Assert.IsNotNull(result.Data);
+			Assert.That(result.DataPtr is not null);
 			Assert.AreEqual(result.Data.Length, result.Width * result.Height * 4);
 		}
 
 		[TestCase("sample_1280×853.hdr", 1280, 853, ColorComponents.RedGreenBlue)]
-		public void LoadHdr(string filename, int width, int height, ColorComponents colorComponents)
+		public unsafe void LoadHdr(string filename, int width, int height, ColorComponents colorComponents)
 		{
-			ImageResultFloat result = null;
-			using(var stream = _assembly.OpenResourceStream(filename))
-			{
-				result = ImageResultFloat.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
-			}
+			using var stream = _assembly.OpenResourceStream(filename);
+			using var result = ImageResultFloat.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
 
 			Assert.IsNotNull(result);
 			Assert.AreEqual(result.Width, width);
 			Assert.AreEqual(result.Height, height);
 			Assert.AreEqual(result.Comp, ColorComponents.RedGreenBlueAlpha);
 			Assert.AreEqual(result.SourceComp, colorComponents);
-			Assert.IsNotNull(result.Data);
+			Assert.That(result.DataPtr is not null);
 			Assert.AreEqual(result.Data.Length, result.Width * result.Height * 4);
 		}
 
@@ -90,7 +81,7 @@ namespace StbImageSharp.Tests
 		}
 
 		[TestCase("somersault.gif", 384, 480, ColorComponents.RedGreenBlueAlpha, 43)]
-		public void AnimatedGifFrames(string fileName, int width, int height, ColorComponents colorComponents, int originalFrameCount)
+		public unsafe void AnimatedGifFrames(string fileName, int width, int height, ColorComponents colorComponents, int originalFrameCount)
 		{
 			using (var stream = _assembly.OpenResourceStream(fileName))
 			{
@@ -100,7 +91,7 @@ namespace StbImageSharp.Tests
 					Assert.AreEqual(frame.Width, width);
 					Assert.AreEqual(frame.Height, height);
 					Assert.AreEqual(frame.Comp, colorComponents);
-					Assert.IsNotNull(frame.Data);
+					Assert.That(frame.DataPtr is not null);
 					Assert.AreEqual(frame.Data.Length, frame.Width * frame.Height * (int)frame.Comp);
 
 					++frameCount;

--- a/tests/StbImageSharp.Viewer/ViewerGame.cs
+++ b/tests/StbImageSharp.Viewer/ViewerGame.cs
@@ -60,9 +60,9 @@ namespace StbImageSharp.Samples.MonoGame
 			{
 				if (!_isAnimatedGif)
 				{
-					var image = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
+					using var image = ImageResult.FromStream(stream, ColorComponents.RedGreenBlueAlpha);
 					var texture = new Texture2D(GraphicsDevice, image.Width, image.Height, false, SurfaceFormat.Color);
-					texture.SetData(image.Data);
+					texture.SetData(image.Data.ToArray());
 
 					var frame = new FrameInfo
 					{
@@ -77,8 +77,8 @@ namespace StbImageSharp.Samples.MonoGame
 					_totalDelayInMs = 0;
 					foreach(var image in ImageResult.AnimatedGifFramesFromStream(stream))
 					{
-						var texture = new Texture2D(GraphicsDevice, image.Width, image.Height, false, SurfaceFormat.Color);
-						texture.SetData(image.Data);
+						using var texture = new Texture2D(GraphicsDevice, image.Width, image.Height, false, SurfaceFormat.Color);
+						texture.SetData(image.Data.ToArray());
 
 						var frame = new FrameInfo
 						{


### PR DESCRIPTION
By utilizing `Span` a speedup of ~1.25 can be achieved!

```
span
24 -- StbImageSharp - psd: 0 ms, png: 10752 ms, jpg: 1315 ms, tga: 599 ms, bmp: 34 ms, Total: 12700 ms
24 -- Stb.Native - psd: 2 ms, png: 9891 ms, jpg: 912 ms, tga: 412 ms, bmp: 25 ms, Total: 11242 ms
24 -- ImageSharp - png: 4018 ms, jpg: 351 ms, tga: 93 ms, bmp: 4 ms, Total: 4477 ms

master
20 -- StbImageSharp - psd: 1 ms, tga: 1001 ms, png: 13915 ms, bmp: 40 ms, jpg: 1998 ms, Total: 16955 ms
20 -- Stb.Native - psd: 1 ms, tga: 567 ms, png: 11754 ms, bmp: 31 ms, jpg: 1454 ms, Total: 13807 ms
20 -- ImageSharp - tga: 191 ms, png: 5543 ms, bmp: 10 ms, jpg: 518 ms, Total: 6279 ms
```
(ImageSharp speedup results from the utilization of their `Span` instead of calling `ToArray` as well)

Downsides are a necessary version bump, slightly more complicated test code, as well as having the `ImageResult` having unmanaged members (resulting in `IDisposable`).

Personally I would say the speedup warrants the cost, however, I could see how a different conclusion can be reached.

If backwards compatibility is required, something along the lines of `byte[] Data => DataSpan.ToArray();` could be implemented.

Closes #18 
Includes #19 