### PR TITLE
Undo optimization to maintain .net 4.5 compatibility

### DIFF
--- a/src/Hebron.Runtime/CRuntime.cs
+++ b/src/Hebron.Runtime/CRuntime.cs
@@ -33,7 +33,10 @@ namespace Hebron.Runtime
 
 		public static void memcpy(void* a, void* b, long size)
 		{
-			Buffer.MemoryCopy(b, a, size, size);
+			var ap = (byte*)a;
+			var bp = (byte*)b;
+			for (long i = 0; i < size; ++i)
+				*ap++ = *bp++;
 		}
 
 		public static void memcpy(void* a, void* b, ulong size)


### PR DESCRIPTION
Related to #25  There is one more piece of code that is holding me up from being able to upgrade the StbImageSharp version in MonoGame. We pass the C# check now, but it also has to work with .NET 4.5 until we're fully off of Brute and onto NativeAOT for consoles. :(

This involves undoing an optimization that was done a few months ago. Buffer.MemoryCopy is a 4.6 feature. Once we have a good master commit that can be updated in the MonoGame submodule we could probably optimize it again... Let me know if you have any concerns or recommendations for this.

// Not .NET 4.5 compatible, but preferred
Buffer.MemoryCopy(b, a, size, size);

// .NET 4.5 compatible
var ap = (byte*)a;
var bp = (byte*)b;
for (long i = 0; i < size; ++i)
	*ap++ = *bp++;