### PR TITLE
Patched for NativeAOT + .NET 10

### DIFF
--- a/src/AnimatedFrameResult.cs
+++ b/src/AnimatedFrameResult.cs
@@ -1,12 +1,11 @@
-﻿namespace StbImageSharp
-{
+namespace StbImageSharp;
+
 #if !STBSHARP_INTERNAL
-	public
+public
 #else
-	internal
+internal
 #endif
-	class AnimatedFrameResult : ImageResult
-	{
-		public int DelayInMs { get; set; }
-	}
+class AnimatedFrameResult : ImageResult
+{
+	public int DelayInMs { get; set; }
 }

--- a/src/AnimatedGifEnumerator.cs
+++ b/src/AnimatedGifEnumerator.cs
@@ -1,146 +1,114 @@
-﻿using Hebron.Runtime;
-using System;
+using Hebron.Runtime;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 
-namespace StbImageSharp
+namespace StbImageSharp;
+
+internal class AnimatedGifEnumerator : IEnumerator<AnimatedFrameResult>
 {
-	internal class AnimatedGifEnumerator : IEnumerator<AnimatedFrameResult>
+	private readonly StbImage.stbi__context _context;
+	private readonly ColorComponents _colorComponents;
+	private StbImage.stbi__gif? _gif;
+	private AnimatedFrameResult? _current;
+
+	public AnimatedGifEnumerator(Stream input, ColorComponents colorComponents)
 	{
-		private readonly StbImage.stbi__context _context;
-		private StbImage.stbi__gif _gif;
-		private readonly ColorComponents _colorComponents;		
+		ArgumentNullException.ThrowIfNull(input);
 
-		public AnimatedGifEnumerator(Stream input, ColorComponents colorComponents)
-		{
-			if (input == null) throw new ArgumentNullException("input");
+		_context = new StbImage.stbi__context(input);
 
-			_context = new StbImage.stbi__context(input);
+		if (StbImage.stbi__gif_test(_context) == 0)
+			throw new InvalidOperationException("Input stream is not GIF file.");
 
-			if (StbImage.stbi__gif_test(_context) == 0) throw new Exception("Input stream is not GIF file.");
-
-			_gif = new StbImage.stbi__gif();
-			_colorComponents = colorComponents;
-		}
-
-		public ColorComponents ColorComponents
-		{
-			get
-			{
-				return _colorComponents;
-			}
-		}
-
-		public AnimatedFrameResult Current { get; private set; }
-
-		object IEnumerator.Current
-		{
-			get
-			{
-				return Current;
-			}
-		}
-
-		public void Dispose()
-		{
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
-
-		public unsafe bool MoveNext()
-		{
-			// Read next frame
-			int ccomp;
-			byte two_back;
-			var result = StbImage.stbi__gif_load_next(_context, _gif, &ccomp, (int)ColorComponents, &two_back);
-			if (result == null) return false;
-
-			if (Current == null)
-			{
-				Current = new AnimatedFrameResult
-				{
-					Width = _gif.w,
-					Height = _gif.h,
-					SourceComp = (ColorComponents)ccomp,
-					Comp = ColorComponents == ColorComponents.Default ? (ColorComponents)ccomp : ColorComponents
-				};
-
-				Current.Data = new byte[Current.Width * Current.Height * (int)Current.Comp];
-			}
-
-			Current.DelayInMs = _gif.delay;
-
-			Marshal.Copy(new IntPtr(result), Current.Data, 0, Current.Data.Length);
-
-			return true;
-		}
-
-		public void Reset()
-		{
-			throw new NotImplementedException();
-		}
-
-		~AnimatedGifEnumerator()
-		{
-			Dispose(false);
-		}
-
-		protected unsafe virtual void Dispose(bool disposing)
-		{
-			if (_gif != null)
-			{
-				if (_gif._out_ != null)
-				{
-					CRuntime.free(_gif._out_);
-					_gif._out_ = null;
-				}
-
-				if (_gif.history != null)
-				{
-					CRuntime.free(_gif.history);
-					_gif.history = null;
-				}
-
-				if (_gif.background != null)
-				{
-					CRuntime.free(_gif.background);
-					_gif.background = null;
-				}
-
-				_gif = null;
-			}
-		}
+		_gif = new StbImage.stbi__gif();
+		_colorComponents = colorComponents;
 	}
 
-	internal class AnimatedGifEnumerable : IEnumerable<AnimatedFrameResult>
+	public ColorComponents ColorComponents => _colorComponents;
+
+	public AnimatedFrameResult Current =>
+		_current ?? throw new InvalidOperationException("Enumeration has not started.");
+
+	object IEnumerator.Current => Current;
+
+	public void Dispose()
 	{
-		private readonly Stream _input;
-		private readonly ColorComponents _colorComponents;		
-
-		public AnimatedGifEnumerable(Stream input, ColorComponents colorComponents)
-		{
-			_input = input;
-			_colorComponents = colorComponents;
-		}
-
-		public ColorComponents ColorComponents
-		{
-			get
-			{
-				return _colorComponents;
-			}
-		}
-
-		public IEnumerator<AnimatedFrameResult> GetEnumerator()
-		{
-			return new AnimatedGifEnumerator(_input, ColorComponents);
-		}
-
-		IEnumerator IEnumerable.GetEnumerator()
-		{
-			return GetEnumerator();
-		}
+		Dispose(true);
+		GC.SuppressFinalize(this);
 	}
+
+	public unsafe bool MoveNext()
+	{
+		var gif = _gif ?? throw new ObjectDisposedException(nameof(AnimatedGifEnumerator));
+
+		int ccomp;
+		byte two_back;
+		var result = StbImage.stbi__gif_load_next(_context, gif, &ccomp, (int)ColorComponents, &two_back);
+		if (result == null) return false;
+
+		if (_current == null)
+		{
+			var comp = ColorComponents == ColorComponents.Default
+				? (ColorComponents)ccomp
+				: ColorComponents;
+
+			_current = new AnimatedFrameResult
+			{
+				Width = gif.w,
+				Height = gif.h,
+				SourceComp = (ColorComponents)ccomp,
+				Comp = comp,
+				Data = new byte[gif.w * gif.h * (int)comp]
+			};
+		}
+
+		_current.DelayInMs = gif.delay;
+
+		new ReadOnlySpan<byte>(result, _current.Data.Length).CopyTo(_current.Data);
+
+		return true;
+	}
+
+	public void Reset() => throw new NotSupportedException();
+
+	~AnimatedGifEnumerator()
+	{
+		Dispose(false);
+	}
+
+	protected unsafe virtual void Dispose(bool disposing)
+	{
+		if (_gif == null)
+			return;
+
+		if (_gif._out_ != null)
+		{
+			CRuntime.free(_gif._out_);
+			_gif._out_ = null;
+		}
+
+		if (_gif.history != null)
+		{
+			CRuntime.free(_gif.history);
+			_gif.history = null;
+		}
+
+		if (_gif.background != null)
+		{
+			CRuntime.free(_gif.background);
+			_gif.background = null;
+		}
+
+		_gif = null;
+	}
+}
+
+internal class AnimatedGifEnumerable(Stream input, ColorComponents colorComponents) : IEnumerable<AnimatedFrameResult>
+{
+	public ColorComponents ColorComponents => colorComponents;
+
+	public IEnumerator<AnimatedFrameResult> GetEnumerator() => new AnimatedGifEnumerator(input, ColorComponents);
+
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/ColorComponents.cs
+++ b/src/ColorComponents.cs
@@ -1,16 +1,15 @@
-﻿namespace StbImageSharp
-{
+namespace StbImageSharp;
+
 #if !STBSHARP_INTERNAL
-	public
+public
 #else
-	internal
+internal
 #endif
-	enum ColorComponents
-	{
-		Default,
-		Grey,
-		GreyAlpha,
-		RedGreenBlue,
-		RedGreenBlueAlpha
-	}
+enum ColorComponents
+{
+	Default,
+	Grey,
+	GreyAlpha,
+	RedGreenBlue,
+	RedGreenBlueAlpha
 }

--- a/src/Hebron.Runtime/MemoryStats.cs
+++ b/src/Hebron.Runtime/MemoryStats.cs
@@ -1,27 +1,14 @@
-﻿using System.Threading;
+using System.Threading;
 
-namespace Hebron.Runtime
+namespace Hebron.Runtime;
+
+internal static class MemoryStats
 {
-	internal unsafe static class MemoryStats
-	{
-		private static int _allocations;
-		 
-		public static int Allocations
-		{
-			get
-			{
-				return _allocations;
-			}
-		}
+	private static int _allocations;
 
-		internal static void Allocated()
-		{
-			Interlocked.Increment(ref _allocations);
-		}
+	public static int Allocations => _allocations;
 
-		internal static void Freed()
-		{
-			Interlocked.Decrement(ref _allocations);
-		}
-	}
+	internal static void Allocated() => Interlocked.Increment(ref _allocations);
+
+	internal static void Freed() => Interlocked.Decrement(ref _allocations);
 }

--- a/src/Hebron.Runtime/Utility.cs
+++ b/src/Hebron.Runtime/Utility.cs
@@ -1,16 +1,15 @@
-﻿namespace Hebron.Runtime
-{
-	internal class Utility
-	{
-		public static T[][] CreateArray<T>(int d1, int d2)
-		{
-			var result = new T[d1][];
-			for (int i = 0; i < d1; i++)
-			{
-				result[i] = new T[d2];
-			}
+namespace Hebron.Runtime;
 
-			return result;
+internal class Utility
+{
+	public static T[][] CreateArray<T>(int d1, int d2)
+	{
+		var result = new T[d1][];
+		for (int i = 0; i < d1; i++)
+		{
+			result[i] = new T[d2];
 		}
+
+		return result;
 	}
 }

--- a/src/ImageInfo.cs
+++ b/src/ImageInfo.cs
@@ -1,40 +1,38 @@
-﻿using System.IO;
+using System.IO;
 
-namespace StbImageSharp
-{
+namespace StbImageSharp;
+
 #if !STBSHARP_INTERNAL
-	public
+public
 #else
-	internal
+internal
 #endif
-	struct ImageInfo
+struct ImageInfo
+{
+	public int Width;
+	public int Height;
+	public ColorComponents ColorComponents;
+	public int BitsPerChannel;
+
+	public static unsafe ImageInfo? FromStream(Stream stream)
 	{
-		public int Width;
-		public int Height;
-		public ColorComponents ColorComponents;
-		public int BitsPerChannel;
+		int width, height, comp;
+		var context = new StbImage.stbi__context(stream);
 
+		var is16Bit = StbImage.stbi__is_16_main(context) == 1;
+		StbImage.stbi__rewind(context);
 
-		public static unsafe ImageInfo? FromStream(Stream stream)
+		var infoResult = StbImage.stbi__info_main(context, &width, &height, &comp);
+		StbImage.stbi__rewind(context);
+
+		if (infoResult == 0) return null;
+
+		return new ImageInfo
 		{
-			int width, height, comp;
-			var context = new StbImage.stbi__context(stream);
-
-			var is16Bit = StbImage.stbi__is_16_main(context) == 1;
-			StbImage.stbi__rewind(context);
-
-			var infoResult = StbImage.stbi__info_main(context, &width, &height, &comp);
-			StbImage.stbi__rewind(context);
-
-			if (infoResult == 0) return null;
-
-			return new ImageInfo
-			{
-				Width = width,
-				Height = height,
-				ColorComponents = (ColorComponents)comp,
-				BitsPerChannel = is16Bit ? 16 : 8
-			};
-		}
+			Width = width,
+			Height = height,
+			ColorComponents = (ColorComponents)comp,
+			BitsPerChannel = is16Bit ? 16 : 8
+		};
 	}
 }

--- a/src/ImageResult.cs
+++ b/src/ImageResult.cs
@@ -1,79 +1,73 @@
-﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 using Hebron.Runtime;
 
-namespace StbImageSharp
-{
+namespace StbImageSharp;
+
 #if !STBSHARP_INTERNAL
-	public
+public
 #else
-	internal
+internal
 #endif
-	class ImageResult
+class ImageResult
+{
+	public int Width { get; set; }
+	public int Height { get; set; }
+	public ColorComponents SourceComp { get; set; }
+	public ColorComponents Comp { get; set; }
+	public byte[] Data { get; set; } = [];
+
+	internal static unsafe ImageResult FromResult(byte* result, int width, int height, ColorComponents comp,
+		ColorComponents req_comp)
 	{
-		public int Width { get; set; }
-		public int Height { get; set; }
-		public ColorComponents SourceComp { get; set; }
-		public ColorComponents Comp { get; set; }
-		public byte[] Data { get; set; }
+		if (result == null)
+			throw new InvalidOperationException(StbImage.stbi__g_failure_reason);
 
-		internal static unsafe ImageResult FromResult(byte* result, int width, int height, ColorComponents comp,
-			ColorComponents req_comp)
+		var image = new ImageResult
 		{
-			if (result == null)
-				throw new InvalidOperationException(StbImage.stbi__g_failure_reason);
+			Width = width,
+			Height = height,
+			SourceComp = comp,
+			Comp = req_comp == ColorComponents.Default ? comp : req_comp
+		};
 
-			var image = new ImageResult
-			{
-				Width = width,
-				Height = height,
-				SourceComp = comp,
-				Comp = req_comp == ColorComponents.Default ? comp : req_comp
-			};
+		image.Data = new byte[width * height * (int)image.Comp];
+		new ReadOnlySpan<byte>(result, image.Data.Length).CopyTo(image.Data);
 
-			// Convert to array
-			image.Data = new byte[width * height * (int)image.Comp];
-			Marshal.Copy(new IntPtr(result), image.Data, 0, image.Data.Length);
+		return image;
+	}
 
-			return image;
-		}
+	public static unsafe ImageResult FromStream(Stream stream,
+		ColorComponents requiredComponents = ColorComponents.Default)
+	{
+		byte* result = null;
 
-		public static unsafe ImageResult FromStream(Stream stream,
-			ColorComponents requiredComponents = ColorComponents.Default)
+		try
 		{
-			byte* result = null;
+			int x, y, comp;
 
-			try
-			{
-				int x, y, comp;
+			var context = new StbImage.stbi__context(stream);
 
-				var context = new StbImage.stbi__context(stream);
+			result = StbImage.stbi__load_and_postprocess_8bit(context, &x, &y, &comp, (int)requiredComponents);
 
-				result = StbImage.stbi__load_and_postprocess_8bit(context, &x, &y, &comp, (int)requiredComponents);
-
-				return FromResult(result, x, y, (ColorComponents)comp, requiredComponents);
-			}
-			finally
-			{
-				if (result != null)
-					CRuntime.free(result);
-			}
+			return FromResult(result, x, y, (ColorComponents)comp, requiredComponents);
 		}
-
-		public static ImageResult FromMemory(byte[] data, ColorComponents requiredComponents = ColorComponents.Default)
+		finally
 		{
-			using (var stream = new MemoryStream(data))
-			{
-				return FromStream(stream, requiredComponents);
-			}
+			if (result != null)
+				CRuntime.free(result);
 		}
+	}
 
-		public static IEnumerable<AnimatedFrameResult> AnimatedGifFramesFromStream(Stream stream,
-			ColorComponents requiredComponents = ColorComponents.Default)
-		{
-			return new AnimatedGifEnumerable(stream, requiredComponents);
-		}
+	public static ImageResult FromMemory(byte[] data, ColorComponents requiredComponents = ColorComponents.Default)
+	{
+		using var stream = new MemoryStream(data);
+		return FromStream(stream, requiredComponents);
+	}
+
+	public static IEnumerable<AnimatedFrameResult> AnimatedGifFramesFromStream(Stream stream,
+		ColorComponents requiredComponents = ColorComponents.Default)
+	{
+		return new AnimatedGifEnumerable(stream, requiredComponents);
 	}
 }

--- a/src/ImageResultFloat.cs
+++ b/src/ImageResultFloat.cs
@@ -1,73 +1,67 @@
-﻿using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using Hebron.Runtime;
 
-namespace StbImageSharp
-{
+namespace StbImageSharp;
+
 #if !STBSHARP_INTERNAL
-	public
+public
 #else
-	internal
+internal
 #endif
-	class ImageResultFloat
+class ImageResultFloat
+{
+	public int Width { get; set; }
+	public int Height { get; set; }
+	public ColorComponents SourceComp { get; set; }
+	public ColorComponents Comp { get; set; }
+	public float[] Data { get; set; } = [];
+
+	internal static unsafe ImageResultFloat FromResult(float* result, int width, int height, ColorComponents comp,
+		ColorComponents req_comp)
 	{
-		public int Width { get; set; }
-		public int Height { get; set; }
-		public ColorComponents SourceComp { get; set; }
-		public ColorComponents Comp { get; set; }
-		public float[] Data { get; set; }
+		if (result == null)
+			throw new InvalidOperationException(StbImage.stbi__g_failure_reason);
 
-		internal static unsafe ImageResultFloat FromResult(float* result, int width, int height, ColorComponents comp,
-			ColorComponents req_comp)
+		var image = new ImageResultFloat
 		{
-			if (result == null)
-				throw new InvalidOperationException(StbImage.stbi__g_failure_reason);
+			Width = width,
+			Height = height,
+			SourceComp = comp,
+			Comp = req_comp == ColorComponents.Default ? comp : req_comp
+		};
 
-			var image = new ImageResultFloat
-			{
-				Width = width,
-				Height = height,
-				SourceComp = comp,
-				Comp = req_comp == ColorComponents.Default ? comp : req_comp
-			};
+		image.Data = new float[width * height * (int)image.Comp];
+		new ReadOnlySpan<float>(result, image.Data.Length).CopyTo(image.Data);
 
-			// Convert to array
-			image.Data = new float[width * height * (int)image.Comp];
-			Marshal.Copy(new IntPtr(result), image.Data, 0, image.Data.Length);
+		return image;
+	}
 
-			return image;
-		}
+	public static unsafe ImageResultFloat FromStream(Stream stream,
+		ColorComponents requiredComponents = ColorComponents.Default)
+	{
+		float* result = null;
 
-		public static unsafe ImageResultFloat FromStream(Stream stream,
-			ColorComponents requiredComponents = ColorComponents.Default)
+		try
 		{
-			float* result = null;
+			int x, y, comp;
 
-			try
-			{
-				int x, y, comp;
+			var context = new StbImage.stbi__context(stream);
 
-				var context = new StbImage.stbi__context(stream);
+			result = StbImage.stbi__loadf_main(context, &x, &y, &comp, (int)requiredComponents);
 
-				result = StbImage.stbi__loadf_main(context, &x, &y, &comp, (int)requiredComponents);
-
-				return FromResult(result, x, y, (ColorComponents)comp, requiredComponents);
-			}
-			finally
-			{
-				if (result != null)
-					CRuntime.free(result);
-			}
+			return FromResult(result, x, y, (ColorComponents)comp, requiredComponents);
 		}
-
-		public static ImageResultFloat FromMemory(byte[] data,
-			ColorComponents requiredComponents = ColorComponents.Default)
+		finally
 		{
-			using (var stream = new MemoryStream(data))
-			{
-				return FromStream(stream, requiredComponents);
-			}
+			if (result != null)
+				CRuntime.free(result);
 		}
+	}
+
+	public static ImageResultFloat FromMemory(byte[] data,
+		ColorComponents requiredComponents = ColorComponents.Default)
+	{
+		using var stream = new MemoryStream(data);
+		return FromStream(stream, requiredComponents);
 	}
 }

--- a/src/StbImage.cs
+++ b/src/StbImage.cs
@@ -1,94 +1,77 @@
-﻿using Hebron.Runtime;
-using System;
+using Hebron.Runtime;
 using System.IO;
-using System.Runtime.InteropServices;
 
-namespace StbImageSharp
-{
+namespace StbImageSharp;
+
 #if !STBSHARP_INTERNAL
-	public
+public
 #else
-	internal
+internal
 #endif
-	static unsafe partial class StbImage
+static unsafe partial class StbImage
+{
+	public static string? stbi__g_failure_reason;
+	public static readonly char[] stbi__parse_png_file_invalid_chunk = new char[25];
+
+	public static int NativeAllocations => MemoryStats.Allocations;
+
+	public class stbi__context
 	{
-		public static string stbi__g_failure_reason;
-		public static readonly char[] stbi__parse_png_file_invalid_chunk = new char[25];
+		private readonly Stream _stream;
 
-		public static int NativeAllocations
+		public byte[]? _tempBuffer;
+		public int img_n = 0;
+		public int img_out_n = 0;
+		public uint img_x = 0;
+		public uint img_y = 0;
+
+		public stbi__context(Stream stream)
 		{
-			get
-			{
-				return MemoryStats.Allocations;
-			}
+			ArgumentNullException.ThrowIfNull(stream);
+			_stream = stream;
 		}
 
-		public class stbi__context
-		{
-			private readonly Stream _stream;
+		public Stream Stream => _stream;
+	}
 
-			public byte[] _tempBuffer;
-			public int img_n = 0;
-			public int img_out_n = 0;
-			public uint img_x = 0;
-			public uint img_y = 0;
+	private static int stbi__err(string str)
+	{
+		stbi__g_failure_reason = str;
+		return 0;
+	}
 
-			public stbi__context(Stream stream)
-			{
-				if (stream == null)
-					throw new ArgumentNullException("stream");
+	public static byte stbi__get8(stbi__context s)
+	{
+		var b = s.Stream.ReadByte();
+		if (b == -1) return 0;
 
-				_stream = stream;
-			}
+		return (byte)b;
+	}
 
-			public Stream Stream
-			{
-				get
-				{
-					return _stream;
-				}
-			}
-		}
+	public static void stbi__skip(stbi__context s, int skip)
+	{
+		s.Stream.Seek(skip, SeekOrigin.Current);
+	}
 
-		private static int stbi__err(string str)
-		{
-			stbi__g_failure_reason = str;
-			return 0;
-		}
+	public static void stbi__rewind(stbi__context s)
+	{
+		s.Stream.Seek(0, SeekOrigin.Begin);
+	}
 
-		public static byte stbi__get8(stbi__context s)
-		{
-			var b = s.Stream.ReadByte();
-			if (b == -1) return 0;
+	public static int stbi__at_eof(stbi__context s)
+	{
+		return s.Stream.Position == s.Stream.Length ? 1 : 0;
+	}
 
-			return (byte)b;
-		}
+	public static int stbi__getn(stbi__context s, byte* buf, int size)
+	{
+		if (s._tempBuffer == null ||
+			s._tempBuffer.Length < size)
+			s._tempBuffer = new byte[size * 2];
 
-		public static void stbi__skip(stbi__context s, int skip)
-		{
-			s.Stream.Seek(skip, SeekOrigin.Current);
-		}
+		var result = s.Stream.Read(s._tempBuffer, 0, size);
+		s._tempBuffer.AsSpan(0, result).CopyTo(new Span<byte>(buf, result));
 
-		public static void stbi__rewind(stbi__context s)
-		{
-			s.Stream.Seek(0, SeekOrigin.Begin);
-		}
-
-		public static int stbi__at_eof(stbi__context s)
-		{
-			return s.Stream.Position == s.Stream.Length ? 1 : 0;
-		}
-
-		public static int stbi__getn(stbi__context s, byte* buf, int size)
-		{
-			if (s._tempBuffer == null ||
-				s._tempBuffer.Length < size)
-				s._tempBuffer = new byte[size * 2];
-
-			var result = s.Stream.Read(s._tempBuffer, 0, size);
-			Marshal.Copy(s._tempBuffer, 0, new IntPtr(buf), result);
-
-			return result;
-		}
+		return result;
 	}
 }

--- a/src/StbImageSharp.csproj
+++ b/src/StbImageSharp.csproj
@@ -1,17 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <Authors>StbImageSharpTeam</Authors>
-        <Product>StbImageSharp</Product>
-        <PackageId>StbImageSharp</PackageId>
-        <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
-        <Description>C# port of the stb_image.h</Description>
-        <PackageLicenseUrl>Public Domain</PackageLicenseUrl>
-        <PackageProjectUrl>https://github.com/StbSharp/StbImageSharp</PackageProjectUrl>
-        <Version>2.30.15</Version>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Configuration)'=='Release'">
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsAotCompatible>true</IsAotCompatible>
+        <NoWarn>CS8618;CA2014</NoWarn>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Replace Marshal.AllocHGlobal/FreeHGlobal/ReAllocHGlobal with NativeMemory
- Replace Marshal.Copy with Span-based copies
- Modernize CRuntime (NativeMemory.Fill, Span.SequenceCompareTo, Buffer.MemoryCopy)
- Update TFM to net10.0, enable ImplicitUsings, IsAotCompatible
- File-scoped namespaces on non-generated files